### PR TITLE
Investigate PSM regression, re-engineer features for SVM, perf enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ env_logger = "0.8.4"
 rayon = "1.5"
 serde = { version="1.0", features = ["derive"] }
 serde_json = "1.0"
-indicatif = {version = "0.16", features = ["rayon"]}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Proteomics Search Engine in a Weekend!
+# Proteomics database search engine with stellar performance
 
 <img src="figures/TMT_Panel.png" width="800">
 
@@ -13,7 +13,7 @@ Carina has excellent performance characteristics (>2x faster and >2x less memory
 ## Features
 
 - Search by fragment, filter by precursor: blazing fast performance
-- Effortlessly cross-platform
+- Effortlessly cross-platform, effortlessly parallel
 - Small and simple codebase
 - Configuration by JSON files
 - X!Tandem hyperscore function

--- a/src/database.rs
+++ b/src/database.rs
@@ -23,7 +23,9 @@ pub struct Builder {
     peptide_min_len: Option<usize>,
     /// Maximum peptide length that will be fragmented
     peptide_max_len: Option<usize>,
+    /// Minimum peptide monoisotopic mass that will be fragmented
     peptide_min_mass: Option<f32>,
+    /// Maximum peptide monoisotopic mass that will be fragmented
     peptide_max_mass: Option<f32>,
     /// Use target-decoy
     decoy: Option<bool>,
@@ -33,7 +35,7 @@ pub struct Builder {
     n_term_mod: Option<f32>,
     /// Static modifications to add to matching amino acids
     static_mods: Option<HashMap<char, f32>>,
-    /// Fasta database
+    /// Path to fasta database
     fasta: PathBuf,
 }
 
@@ -92,7 +94,6 @@ impl Parameters {
 
         let trypsin = Trypsin::new(
             self.decoy,
-            // false,
             self.missed_cleavages,
             self.peptide_min_len,
             self.peptide_max_len,
@@ -361,9 +362,9 @@ where
         }
     };
 
-    let right_idx = match slice.binary_search_by(|a| key(a).total_cmp(&high)) {
+    let right_idx = match slice[left_idx..].binary_search_by(|a| key(a).total_cmp(&high)) {
         Ok(idx) | Err(idx) => {
-            let mut idx = idx;
+            let mut idx = idx + left_idx;
             while idx < slice.len() && key(&slice[idx]) <= high {
                 idx = idx.saturating_add(1);
             }

--- a/src/database.rs
+++ b/src/database.rs
@@ -113,7 +113,9 @@ impl Parameters {
         let mut target_decoys = peptides
             .par_iter()
             .filter_map(|f| Peptide::try_from(f).ok().map(|pep| (f, pep)))
-            .filter(|(_, p)| p.monoisotopic >= self.peptide_min_mass && p.monoisotopic <= self.peptide_max_mass)
+            .filter(|(_, p)| {
+                p.monoisotopic >= self.peptide_min_mass && p.monoisotopic <= self.peptide_max_mass
+            })
             // .flat_map(|(digest, mut peptide)|  {
             //     let mut reversed = peptide.clone();
             //     reversed.sequence.reverse();

--- a/src/ion_series.rs
+++ b/src/ion_series.rs
@@ -53,7 +53,6 @@ impl<'p> Iterator for IonSeries<'p> {
         if Kind::Y == self.kind {
             monoisotopic_mass += H2O;
         }
-        // neutral = (neutral + self.charge as f32 * PROTON) / self.charge as f32;
 
         Some(Ion {
             kind: self.kind,

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -14,6 +14,8 @@ pub enum Tolerance {
 }
 
 impl Tolerance {
+    /// Compute the (`lower`, `upper`) window (in Da) for for a monoisotopic
+    /// mass and a given tolerance
     pub fn bounds(&self, center: f32) -> (f32, f32) {
         match self {
             Tolerance::Ppm(ppm) => {

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -10,7 +10,7 @@ pub const NH3: f32 = 17.026548;
 #[serde(rename_all = "lowercase")]
 pub enum Tolerance {
     Ppm(f32),
-    Th(f32),
+    Da(f32),
 }
 
 impl Tolerance {
@@ -22,7 +22,7 @@ impl Tolerance {
                 let delta = center * ppm / 1_000_000.0;
                 (center - delta, center + delta)
             }
-            Tolerance::Th(th) => (center - th, center + th),
+            Tolerance::Da(th) => (center - th, center + th),
         }
     }
 }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -27,7 +27,7 @@ impl SpectrumProcessor {
     pub fn process(&self, mut s: Spectrum) -> ProcessedSpectrum {
         let charge = self.max_fragment_charge.min(s.charge);
 
-        s.peaks.sort_by(|(_, a), (_, b)| b.total_cmp(&a));
+        s.peaks.sort_unstable_by(|(_, a), (_, b)| b.total_cmp(&a));
         let n = s.peaks.len().min(self.take_top_n);
         let mut peaks = s.peaks[..n]
             .iter()
@@ -49,7 +49,7 @@ impl SpectrumProcessor {
             .collect::<Vec<_>>();
 
         // Sort by m/z
-        peaks.sort_by(|a, b| a.0.total_cmp(&b.0));
+        peaks.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
 
         ProcessedSpectrum {
             scan: s.scan,


### PR DESCRIPTION
`spectrum_q_value` is probably cheating and leaking some latent information about target/decoy class (#1).
Instead, we compute other features on the candidate peptide-spectrum level that are agnostic to target/decoy class:

- matched_intensity_pct: percentage of total MS2 signal that the matched peaks account for,
- delta_matched: difference between # of matched peaks of reported PSM, and the average peaks/candidate
- scored_candidates: # of candidates actually scored 
- spectrum_z_score: z-score of candidate hyperscore vs median hyperscore of all candidates

Additional perf enhancements:
- Remove `HashMap` from `Scorer::score` and pre-allocating a score vector based on the theoretical # of candidates that can be scored
- Use `sort_unstable` rather than `sort`

![image](https://user-images.githubusercontent.com/14057244/180621694-d9af81f4-7472-4219-a0e3-7d5f3f0c7fbe.png)

Perf on 4-core i5-4690k, 16 GB desktop